### PR TITLE
v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ If you want to run the bot at startup, or advanced configuration, check the [Wik
   
 ## Roadmap
 - [X] Basic functionality, only */start* and */help* commands. [`v0.1.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.1.0)
-- [X] Add a list of allowed users who can interact with the bot. [`v0.2.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.2.0)
-- [X] Add a list of admin users who can run admin restricted commands. [`v0.3.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.3.0)
+- [X] Added a list of allowed users who can interact with the bot. [`v0.2.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.2.0)
+- [X] Added a list of admin users who can run admin restricted commands. [`v0.3.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.3.0)
 - [X] Fixed a bug with admin restricted commands. [`v0.3.1`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.3.1)
-- [X] Add */reboot* command, restricted to admin users. [`v0.4.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.4.0)
-- [X] Add confirmation buttons to execute */reboot* command. [`v0.4.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.4.0)
+- [X] Added */reboot* command, restricted to admin users. [`v0.4.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.4.0)
+- [X] Added confirmation buttons to execute */reboot* command. [`v0.4.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.4.0)
 - [X] Critical data like Telegram bot token, allowed users list and admin users list are stored in external separate JSON files. [`v0.5.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.5.0)
-- [X] Add */system* command so admins can check CPU temperature of server, CPU and RAM load. [`v0.6.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.0)
+- [X] Added */system* command so admins can check CPU temperature of server, CPU and RAM load. [`v0.6.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.0)
 - [X] The information displayed by */system* command is grouped into one unique message. [`v0.6.1`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.1)
+- [X] CPU Temperature is available only in Linux due to limitations of gpiozero library. Added OS check to bypass CPU Temperature measurement. [`v0.6.2`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.2)
 - [ ] Add */listusers* command so any user can check allowed users list.
 - [ ] Add */adduser* command so admins can add users to the allowed users list.
 - [ ] Add */removeuser* command so admins can remove users from the allowed users list.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Edit ***smarthomebot.json*** and add your bot Telegram token. Edit ***allowed_us
 python smarthomebot.py
 ```
   
-If you want the bot to run at startup, or advanced configuration, check the [Wiki](https://github.com/Geek-MD/SmartHomeBot/wiki).
+If you want to run the bot at startup, or advanced configuration, check the [Wiki](https://github.com/Geek-MD/SmartHomeBot/wiki).
   
 ## Roadmap
 - [X] Basic functionality, only */start* and */help* commands. [`v0.1.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.1.0)
@@ -47,7 +47,7 @@ If you want the bot to run at startup, or advanced configuration, check the [Wik
 - [X] Add confirmation buttons to execute */reboot* command. [`v0.4.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.4.0)
 - [X] Critical data like Telegram bot token, allowed users list and admin users list are stored in external separate JSON files. [`v0.5.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.5.0)
 - [X] Add */system* command so admins can check CPU temperature of server, CPU and RAM load. [`v0.6.0`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.0)
-- [X] Group information displayed by */system* command into one unique message. [`v0.6.1`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.1)
+- [X] The information displayed by */system* command is grouped into one unique message. [`v0.6.1`](https://github.com/Geek-MD/SmartHomeBot/releases/tag/v0.6.1)
 - [ ] Add */listusers* command so any user can check allowed users list.
 - [ ] Add */adduser* command so admins can add users to the allowed users list.
 - [ ] Add */removeuser* command so admins can remove users from the allowed users list.

--- a/smarthomebot.py
+++ b/smarthomebot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# SmartHomeBot v0.6.1
+# SmartHomeBot v0.6.2
 # A simple Telegram Bot used to automate notifications for a Smart Home.
 # The bot starts automatically and runs until you press Ctrl-C on the command line.
 #
@@ -69,13 +69,17 @@ def reboot_query(update: Update, context: CallbackContext) -> None:
             continue
 
 def system_command(update: Update, context: CallbackContext) -> None:
-    cpu_temp = CPUTemperature()
-    cpu_temp_esc = re.escape(str(round(cpu_temp.temperature, 1)))
+    if psutil.LINUX == False:
+        # skip CPU temperature if OS is not Linux.
+        system_msg = '*CPU temperature:* _Not available_\n'
+    else:
+        cpu_temp = CPUTemperature()
+        cpu_temp_esc = re.escape(str(round(cpu_temp.temperature, 1)))
+        system_msg = '*CPU temperature:* ' + cpu_temp_esc + '°C\n'
     cpu_load = psutil.cpu_percent(4)
     cpu_load_esc = re.escape(str(round(cpu_load, 1)))
     ram_load = psutil.virtual_memory()
     ram_load_esc = re.escape(str(round(ram_load.percent, 1)))
-    system_msg = '*CPU temperature:* ' + cpu_temp_esc + '°C\n'
     system_msg += '*CPU load:* ' + cpu_load_esc + '%\n'
     system_msg += '*RAM load:* ' + ram_load_esc + '%'
     update.message.reply_markdown_v2(system_msg)


### PR DESCRIPTION
CPU Temperature is available only in Linux due to limitations of gpiozero library. Added OS check to bypass CPU Temperature measurement.